### PR TITLE
fix(api): resolve when file is done being written to fs

### DIFF
--- a/api/resolvers.mjs
+++ b/api/resolvers.mjs
@@ -26,8 +26,9 @@ const storeFS = ({ stream, filename }) => {
           fs.unlinkSync(path)
         reject(error)
       })
-      .on('end', () => resolve({ id, path }))
       .pipe(fs.createWriteStream(path))
+      .on('error', error => reject(error))
+      .on('finish', () => resolve({ id, path }))
   )
 }
 


### PR DESCRIPTION
When using this example as a model for implementing my own server. I ran into an issue where in some cases the file size written to the database was 0 bytes. I realized it was due to the fact that the resolution for the storeFS function occurred when the upload stream ended, and not when the file was done being written to the file system to be picked up later.

This PR updates the example to prevent that edge case and resolve instead when the file is finished being written to the local fs and is ready to be stored elsewhere.